### PR TITLE
Fix training batch handling and decay cleanup

### DIFF
--- a/QA_RESULTS.md
+++ b/QA_RESULTS.md
@@ -1,0 +1,35 @@
+# SocialGNN QA Results (2025-09-25)
+
+## Environment
+- Repo commit (pre-change baseline): 959617dd51c9da45bb0d630f493a2634a8392ee4
+- Go toolchain: go1.22.2 linux/amd64
+- QA agent: Codex CLI (danger-full-access; outbound and loopback networking available)
+
+## Automated Checks
+- `go test ./...` → Pass (new unit tests added under `internal/engine`)
+- `go vet ./...` → Pass (no findings)
+
+## Manual QA
+- Started the API with `PORT=8090 LOAD_SAMPLE_DATA=true go run cmd/server/main.go` and exercised key endpoints:
+  - `GET /health` → 200 with healthy status payload
+  - `GET /api/stats` → 200 with node/edge counts
+  - `GET /api/recommendations/sarah?limit=3` → 200, returns ranked posts
+  - `GET /api/persuasiveness/sarah` → 200 with score payload
+  - `GET /api/followback/sarah` → 200 with mutual follow metrics
+- Added training interactions via `POST /api/train/example` and invoked `POST /api/train/batch` with `{"epochs":3,"batch_size":5}` → 200 with loss/epoch summary even when only two examples exist (regression scenario fixed).
+- Built and ran `/tmp/socialgnn_test`, created a brand-new user through `POST /api/nodes`, and confirmed `GET /api/followback/newbie` now returns zeroed metrics (previously 404).
+- Observed that calling `POST /api/train/batch` without any stored training examples returns HTTP 500, matching the engine-side validation (`no training data available`).
+
+## Fixes Implemented
+1. **Training batch semantics** (`internal/api/server.go`, `internal/engine/engine.go`, `internal/engine/gnn.go`)
+   - Added explicit `batch_size` support, sensible defaults, and epoch looping so training runs even when requested batches exceed the number of stored examples. Engine now surfaces a clear error only when no training data exists. Included regression test `TestEngineTrainBatchHandlesLargeBatch`.
+2. **Followback metrics for inactive users** (`internal/engine/engine.go`)
+   - The engine now verifies user existence before returning metrics and no longer treats "all zero" as missing data. Covered by `TestGetFollowbackMetricsReturnsZerosForNewUsers`.
+3. **Temporal decay cleanup** (`internal/engine/graph.go`)
+   - Edges older than `maxAge` are deleted, decayed weights below 0.1 are purged, and empty adjacency maps are cleaned up, matching documentation guarantees. Verified by `TestApplyDecayRemovesExpiredAndWeakEdges`.
+4. **Test coverage improvements**
+   - Added targeted unit tests in `internal/engine` to capture the above behaviors and guard against regressions.
+
+## Remaining Observations
+- API-level integration tests are still absent; consider adding HTTP handler tests covering the training, followback, and recommendation flows.
+- Training endpoints respond with HTTP 500 when no training data exists; this is intentional but may warrant a friendlier API message depending on product requirements.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,55 @@
+package engine
+
+import "testing"
+
+func TestEngineTrainBatchHandlesLargeBatch(t *testing.T) {
+	engine := NewEngine()
+
+	if err := engine.AddNode("user1", UserNode, map[string]interface{}{"name": "User"}); err != nil {
+		t.Fatalf("failed to add user: %v", err)
+	}
+	if err := engine.AddNode("post1", PostNode, map[string]interface{}{"author": "user1"}); err != nil {
+		t.Fatalf("failed to add post: %v", err)
+	}
+	if err := engine.AddEdge("user1", "post1", 1.0, "like"); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	if err := engine.AddTrainingExample("user1", "post1", 1.0); err != nil {
+		t.Fatalf("failed to add training example: %v", err)
+	}
+
+	if _, err := engine.TrainBatch(3, 5); err != nil {
+		t.Fatalf("expected training to succeed, got error: %v", err)
+	}
+}
+
+func TestEngineTrainBatchRequiresTrainingData(t *testing.T) {
+	engine := NewEngine()
+	if _, err := engine.TrainBatch(1, 2); err == nil {
+		t.Fatal("expected error when no training data is available")
+	}
+}
+
+func TestGetFollowbackMetricsReturnsZerosForNewUsers(t *testing.T) {
+	engine := NewEngine()
+	if err := engine.AddNode("loner", UserNode, map[string]interface{}{"name": "Solo"}); err != nil {
+		t.Fatalf("failed to add user: %v", err)
+	}
+
+	metrics, err := engine.GetFollowbackMetrics("loner")
+	if err != nil {
+		t.Fatalf("expected metrics for existing user, got error: %v", err)
+	}
+
+	if metrics.Followers != 0 || metrics.Following != 0 || metrics.Followbacks != 0 {
+		t.Fatalf("expected zeroed metrics for new user, got %+v", metrics)
+	}
+}
+
+func TestGetFollowbackMetricsMissingUser(t *testing.T) {
+	engine := NewEngine()
+	if _, err := engine.GetFollowbackMetrics("ghost"); err == nil {
+		t.Fatal("expected error for missing user")
+	}
+}

--- a/internal/engine/graph_test.go
+++ b/internal/engine/graph_test.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestApplyDecayRemovesExpiredAndWeakEdges(t *testing.T) {
+	graph := NewGraph()
+
+	nodes := []struct {
+		id       string
+		nodeType NodeType
+	}{
+		{"a", UserNode},
+		{"b", UserNode},
+		{"c", UserNode},
+		{"d", UserNode},
+		{"x", UserNode},
+	}
+
+	for _, n := range nodes {
+		err := graph.AddNode(&Node{ID: n.id, Type: n.nodeType, Metadata: map[string]interface{}{}})
+		if err != nil {
+			t.Fatalf("failed to add node %s: %v", n.id, err)
+		}
+	}
+
+	if err := graph.AddEdge(&Edge{From: "a", To: "b", Weight: 1.0, EdgeType: "friend"}); err != nil {
+		t.Fatalf("failed to add edge a->b: %v", err)
+	}
+	if err := graph.AddEdge(&Edge{From: "a", To: "c", Weight: 0.2, EdgeType: "friend"}); err != nil {
+		t.Fatalf("failed to add edge a->c: %v", err)
+	}
+	if err := graph.AddEdge(&Edge{From: "a", To: "d", Weight: 0.9, EdgeType: "friend"}); err != nil {
+		t.Fatalf("failed to add edge a->d: %v", err)
+	}
+	if err := graph.AddEdge(&Edge{From: "x", To: "b", Weight: 0.4, EdgeType: "friend"}); err != nil {
+		t.Fatalf("failed to add edge x->b: %v", err)
+	}
+
+	now := time.Now()
+	graph.edges["a"]["b"].UpdatedAt = now.Add(-200 * time.Hour) // beyond max age
+	graph.edges["a"]["c"].UpdatedAt = now.Add(-48 * time.Hour)  // will decay below threshold
+	graph.edges["a"]["d"].UpdatedAt = now.Add(-2 * time.Hour)
+	graph.edges["x"]["b"].UpdatedAt = now.Add(-300 * time.Hour)
+
+	graph.ApplyDecay(0.1, 168*time.Hour)
+
+	if _, exists := graph.edges["a"]["b"]; exists {
+		t.Fatal("expected a->b edge to be removed after exceeding max age")
+	}
+	if _, exists := graph.edges["a"]["c"]; exists {
+		t.Fatal("expected a->c edge to be removed after decaying below threshold")
+	}
+
+	edgeAD, exists := graph.edges["a"]["d"]
+	if !exists {
+		t.Fatal("expected a->d edge to persist")
+	}
+	if edgeAD.Weight <= 0.1 || edgeAD.Weight >= 0.9 {
+		t.Fatalf("expected a->d weight to be decayed but above threshold, got %f", edgeAD.Weight)
+	}
+
+	if _, exists := graph.edges["x"]; exists {
+		t.Fatal("expected x edge map to be removed when all edges decayed")
+	}
+}


### PR DESCRIPTION
## Summary
- add batch size handling and defaults for /api/train/batch and engine training loop
- return zeroed followback metrics for existing but inactive users
- prune expired/weak edges per temporal decay contract and add regression tests

## Testing
- go test ./...
- go vet ./...
- PORT=8090 LOAD_SAMPLE_DATA=true go run cmd/server/main.go (manual endpoint smoke, training batch, followback)
